### PR TITLE
Build tbots toolchain for Ubuntu 20.04 machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ One of the udev rules conflicts with the device id used by our E-stops. Instead,
 
 ## Toolchains
 We have custom toolchains to cross-compile for the Jetson Nano and Raspbery Pi 5.
+
+| Filename | sha256 |
+|----------|--------|
+| aarch64-tbots-linux-gnu-for-x86.tar.xz | c2ed38183926c4264db56890698f41c0019fb82800bc474172b0841f5a1f22ce |
+| aarch64-tbots-linux-gnu-for-aarch64.tar.xz | 94181b1742ee72e0d1f8f0b80b9f602da6e7455b8fdc11a1690a55a5aff46cb3 |

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ We host the following mirrors in case the original download link is offline
 The BRLTTY service provides access to a console screen for blind people via a braille screen.
 
 One of the udev rules conflicts with the device id used by our E-stops. Instead, we offer alternate udev rules to prevent this conflict.
+
+## Toolchains
+We have custom toolchains to cross-compile for the Jetson Nano and Raspbery Pi 5.

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ We have custom toolchains to cross-compile for the Jetson Nano and Raspbery Pi 5
 
 | Filename | sha256 |
 |----------|--------|
-| aarch64-tbots-linux-gnu-for-x86.tar.xz | c2ed38183926c4264db56890698f41c0019fb82800bc474172b0841f5a1f22ce |
+| aarch64-tbots-linux-gnu-for-x86.tar.xz | 44f65b4d76028ef4e9c3f5cce8249dee60219844dca671278ca78f8aa5fd0726 |
 | aarch64-tbots-linux-gnu-for-aarch64.tar.xz | 94181b1742ee72e0d1f8f0b80b9f602da6e7455b8fdc11a1690a55a5aff46cb3 |


### PR DESCRIPTION
#1 doesn't compile on CI, this is re-built for older GLIBC versions